### PR TITLE
A better style to Process the Params in a ws uri string.

### DIFF
--- a/src/Bird.Socket.Client.pas
+++ b/src/Bird.Socket.Client.pas
@@ -192,7 +192,10 @@ begin
     inherited Connect;
     if not LURI.Port.IsEmpty then
       LURI.Host := LURI.Host + ':' + LURI.Port;
-    FSocket.WriteLn(Format('GET %s HTTP/1.1', [LURI.Path + LURI.Document]));
+    if (LURI.Params <> '') then
+      FSocket.WriteLn(Format('GET %s HTTP/1.1', [LURI.Path + LURI.Document + '?' + LURI.Params]))
+    else
+      FSocket.WriteLn(Format('GET %s HTTP/1.1', [LURI.Path + LURI.Document]));
     FSocket.WriteLn(Format('Host: %s', [LURI.Host]));
     FSocket.WriteLn('User-Agent: Delphi WebSocket Simple Client');
     FSocket.WriteLn('Connection: keep-alive, Upgrade');


### PR DESCRIPTION
Hello @mateusvicente100 

Sorry for this pull, as When I test with ws://echo.websocket.org,  the server will response to a refuse to connect error when the URI add a '?',   but in my browser test with ws://echo.websocket.org, there is no problem. 

So I change this to a if command to process the Params when there are real Params in the URI before to submit to the server. 

Thank you. 